### PR TITLE
Default Block Grid Editor Width set to clamp(576px, 100%, 1400px)

### DIFF
--- a/Umbootstrap.Web/uSync/v9/DataTypes/ContentGridDefaultContentBlockGrid.config
+++ b/Umbootstrap.Web/uSync/v9/DataTypes/ContentGridDefaultContentBlockGrid.config
@@ -477,7 +477,7 @@
   "CreateLabel": "Add a Layout Block",
   "GridColumns": null,
   "LayoutStylesheet": null,
-  "MaxPropertyWidth": null,
+  "MaxPropertyWidth": "clamp(576px, 100%, 1400px)",
   "UseLiveEditing": false,
   "ValidationLimit": {
     "max": null,


### PR DESCRIPTION
i.e. Bootstraps breakpoints