### PR TITLE
Proposed update template-pack.csproj for Marketplace listing

### DIFF
--- a/template-pack.csproj
+++ b/template-pack.csproj
@@ -6,7 +6,7 @@
     <Title>Umbraco.Community.Templates.UmBootstrap</Title>
     <Authors>Dean Leigh</Authors>
     <Description>A project template for creating a new Umbraco site using the UmBootstrap Starter Kit</Description>
-    <PackageTags>dotnet-new;templates;umbraco;bootstrap</PackageTags>
+    <PackageTags>dotnet-new;templates;umbraco;bootstrap;umbraco-marketplace</PackageTags>
 
     <TargetFramework>net6.0</TargetFramework>
 
@@ -23,6 +23,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Umbraco.Cms.Core" Version="10.6.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="Umbootstrap.Web\**\*" Exclude="Umbootstrap.Web\**\bin\**;Umbootstrap.Web\**\obj\**" />


### PR DESCRIPTION
As discussed in https://github.com/umbraco/Umbraco.Marketplace.Issues/issues/53, this PR makes two updates to your `.csproj` file that meets the two requirements that the Umbraco Marketplace has for listing NuGet packages:

- An "umbraco-marketplace" tag.
- A dependency on Umbraco

I'm not 100% sure this will work, but assuming there's nothing else that's differently treated for a NuGet package that's a template versus a normal package, this should be enough to list it.

You should update the Umbraco version I've used to match the minimum version that your template supports.