### PR TITLE
Feature/add unattended install

### DIFF
--- a/Umbootstrap.Web/.template.config/template.json
+++ b/Umbootstrap.Web/.template.config/template.json
@@ -38,7 +38,12 @@
       "type": "parameter",
       "datatype": "string",
       "defaultValue": "",
-      "replaces": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True"
+      "forms": {
+        "global": [
+          "jsonEncode"
+        ]
+      },
+      "replaces": "CONNECTION_STRING_FROM_TEMPLATE"
     },
     "ConnectionStringProviderName": {
       "displayName": "Connection string provider name",
@@ -46,7 +51,123 @@
       "type": "parameter",
       "datatype": "string",
       "defaultValue": "Microsoft.Data.SqlClient",
-      "replaces": "Microsoft.Data.Sqlite"
+      "forms": {
+        "global": [
+          "jsonEncode"
+        ]
+      },
+      "replaces": "CONNECTION_STRING_PROVIDER_NAME_FROM_TEMPLATE"
+    },
+    "HasConnectionString": {
+      "type": "computed",
+      "value": "(ConnectionString != '')"
+    },
+    "DevelopmentDatabaseType": {
+      "displayName": "Development database type",
+      "description": "Database type used by Umbraco for development.",
+      "type": "parameter",
+      "datatype": "choice",
+      "choices": [
+        {
+          "displayName": "None",
+          "description": "Do not configure a database for development.",
+          "choice": "None"
+        },
+        {
+          "displayName": "SQLite",
+          "description": "Use embedded SQLite database.",
+          "choice": "SQLite"
+        },
+        {
+          "displayName": "SQL Server Express LocalDB",
+          "description": "Use embedded LocalDB database (requires SQL Server Express with Advanced Services).",
+          "choice": "LocalDB"
+        }
+      ],
+      "defaultValue": "None"
+    },
+    "DevelopmentConnectionString": {
+      "type": "generated",
+      "datatype": "string",
+      "generator": "switch",
+      "parameters": {
+        "cases": [
+          {
+            "condition": "(DevelopmentDatabaseType == 'SQLite')",
+            "value": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True"
+          },
+          {
+            "condition": "(DevelopmentDatabaseType == 'LocalDB')",
+            "value": "Data Source=(localdb)\\\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\\\Umbraco.mdf;Integrated Security=True"
+          }
+        ]
+      },
+      "replaces": "CONNECTION_STRING_DEVELOPMENT_FROM_TEMPLATE"
+    },
+    "DevelopmentConnectionStringProviderName": {
+      "type": "generated",
+      "datatype": "string",
+      "generator": "switch",
+      "parameters": {
+        "cases": [
+          {
+            "condition": "(DevelopmentDatabaseType == 'SQLite')",
+            "value": "Microsoft.Data.Sqlite"
+          },
+          {
+            "condition": "(true)",
+            "value": "Microsoft.Data.SqlClient"
+          }
+        ]
+      },
+      "replaces": "CONNECTION_STRING_PROVIDER_NAME_DEVELOPMENT_FROM_TEMPLATE"
+    },
+    "HasDevelopmentConnectionString": {
+      "type": "computed",
+      "value": "(DevelopmentConnectionString != '')"
+    },
+    "UnattendedUserName": {
+      "displayName": "Unattended user name",
+      "description": "Used to specify the name of the default admin user when using unattended install on development (stored as plain text).",
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "",
+      "forms": {
+        "global": [
+          "jsonEncode"
+        ]
+      },
+      "replaces": "UNATTENDED_USER_NAME_FROM_TEMPLATE"
+    },
+    "UnattendedUserEmail": {
+      "displayName": "Unattended user email",
+      "description": "Used to specify the email of the default admin user when using unattended install on development (stored as plain text).",
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "",
+      "forms": {
+        "global": [
+          "jsonEncode"
+        ]
+      },
+      "replaces": "UNATTENDED_USER_EMAIL_FROM_TEMPLATE"
+    },
+    "UnattendedUserPassword": {
+      "displayName": "Unattended user password",
+      "description": "Used to specify the password of the default admin user when using unattended install on development (stored as plain text).",
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "",
+      "forms": {
+        "global": [
+          "jsonEncode"
+        ]
+      },
+      "replaces": "UNATTENDED_USER_PASSWORD_FROM_TEMPLATE"
+    },
+    "UsingUnattenedInstall": {
+      "type": "computed",
+      "value": "(UnattendedUserName != '' && UnattendedUserEmail != '' && UnattendedUserPassword != '' && (HasConnectionString || HasDevelopmentConnectionString))"
     }
   },
   "sources": [

--- a/Umbootstrap.Web/appsettings.Development.json
+++ b/Umbootstrap.Web/appsettings.Development.json
@@ -17,8 +17,22 @@
       }
     ]
   },
+  //#if (HasDevelopmentConnectionString)
+  "ConnectionStrings": {
+    "umbracoDbDSN": "CONNECTION_STRING_DEVELOPMENT_FROM_TEMPLATE",
+    "umbracoDbDSN_ProviderName": "CONNECTION_STRING_PROVIDER_NAME_DEVELOPMENT_FROM_TEMPLATE"
+  },
+  //#endif
   "Umbraco": {
     "CMS": {
+      //#if (UsingUnattenedInstall)
+      "Unattended": {
+        "InstallUnattended": true,
+        "UnattendedUserName": "UNATTENDED_USER_NAME_FROM_TEMPLATE",
+        "UnattendedUserEmail": "UNATTENDED_USER_EMAIL_FROM_TEMPLATE",
+        "UnattendedUserPassword": "UNATTENDED_USER_PASSWORD_FROM_TEMPLATE"
+      },
+      //#endif
       "Content": {
         "MacroErrors": "Throw"
       },

--- a/Umbootstrap.Web/appsettings.json
+++ b/Umbootstrap.Web/appsettings.json
@@ -28,10 +28,6 @@
       }
     }
   },
-  "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
-    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
-  },
   "uSync": {
     "Settings": {
       "ImportOnFirstBoot": true

--- a/Umbootstrap.Web/appsettings.json
+++ b/Umbootstrap.Web/appsettings.json
@@ -10,6 +10,12 @@
       }
     }
   },
+  //#if (HasConnectionString)
+  "ConnectionStrings": {
+    "umbracoDbDSN": "CONNECTION_STRING_FROM_TEMPLATE",
+    "umbracoDbDSN_ProviderName": "CONNECTION_STRING_PROVIDER_NAME_FROM_TEMPLATE"
+  },
+  //#endif
   "Umbraco": {
     "CMS": {
       "ModelsBuilder": {


### PR DESCRIPTION
Added the required settings for unattended install to work with the same project symbols that Umbraco uses in their dotnet template. 

This will allow us to install it like this

```ps1
# Ensure we have the latest UmBootstrap template installed
dotnet new install Umbraco.Community.Templates.UmBootstrap

# Create solution/project
dotnet new sln --name "MySolution"
dotnet new umbootstrap --force -n "MyProject" --friendly-name "Administrator" --email "admin@example.com" --password "1234567890" --development-database-type SQLite
dotnet sln add "MyProject"

dotnet run --project "MyProject"
#Running
```

And when you paste the code in the CLI and hit enter, then go to the website url it will have already created the database and then the usync import happens all in one step now.

This will set us up to be able to use UmBootstrao in Package Script Writer too