### PR TITLE
Case sensitivity issue causing templates to throw an exception on Linux

### DIFF
--- a/Umbootstrap.Web/Views/_Layout.cshtml
+++ b/Umbootstrap.Web/Views/_Layout.cshtml
@@ -22,7 +22,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <partial name="Head/_Meta" />
+    <partial name="Head/_meta" />
 
     @*<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">*@
     <link href="~/css/index.css" rel="stylesheet" />


### PR DESCRIPTION
Hi Dean, great work on this template!

I came across an exception when running it on Ubuntu which was due to the case sensitivity of partial view file names:

```console
System.InvalidOperationException: The partial view 'Head/_Meta' was not found. The following locations were searched:
/Views/Partials/blocklist/Components/Head/_Meta.cshtml
/Views/Partials/blockgrid/Components/Head/_Meta.cshtml
/App_Plugins/Views/Render/Head/_Meta.cshtml
/App_Plugins/Views/Shared/Head/_Meta.cshtml
/App_Plugins/Views/Partials/Head/_Meta.cshtml
/App_Plugins/Views/MacroPartials/Head/_Meta.cshtml
/Views/Head/_Meta.cshtml
/Views/Shared/Head/_Meta.cshtml
/Views/Partials/Head/_Meta.cshtml
/Views/MacroPartials/Head/_Meta.cshtml
/Views/Render/Head/_Meta.cshtml
/Views/Shared/Head/_Meta.cshtml
```

The template is named *_meta.cshtml* (lowercase) so I simply corrected this where it is rendered in the layout view.